### PR TITLE
Update WindowsFirewallHelper.targets

### DIFF
--- a/WindowsFirewallHelper/WindowsFirewallHelper.targets
+++ b/WindowsFirewallHelper/WindowsFirewallHelper.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeLibs Include="$(MSBuildThisFileDirectory)*.dll" />
-    <None Include="@(NativeLibs)">
+    <None Include="@(NativeLibs)" Visible="False">
       <Link>%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This ensures the DLL is no longer visible in new csproj file format.