### PR TITLE
LocalPorts Fix

### DIFF
--- a/WindowsFirewallHelper/Helpers/PortHelper.cs
+++ b/WindowsFirewallHelper/Helpers/PortHelper.cs
@@ -17,11 +17,11 @@ namespace WindowsFirewallHelper.Helpers
                 .Select(
                     groups => groups.Count() >= 3
                         ? groups.First().PortNumber + "-" + groups.Last().PortNumber
-                        : string.Join(", ", groups.Select(pair => pair.PortNumber.ToString("")).ToArray())
+                        : string.Join(",", groups.Select(pair => pair.PortNumber.ToString("")).ToArray())
                 )
                 .ToArray();
 
-            return string.Join(", ", portStrings);
+            return string.Join(",", portStrings);
         }
 
         // ReSharper disable once TooManyDeclarations


### PR DESCRIPTION
Setting LocalPorts using PortHelper.PortsToString fails when intervals are separated by ", "(comma followed by space) while it works when using ","