### PR TITLE
Delete or check existence of rule without enumeration of all

### DIFF
--- a/WindowsFirewallHelper.Tests/FirewallLegacyTests.cs
+++ b/WindowsFirewallHelper.Tests/FirewallLegacyTests.cs
@@ -361,6 +361,18 @@ namespace WindowsFirewallHelper.Tests
             );
         }
 
+		 [Test]
+        public void RuleExists()
+        {
+	        var firewall = (IFirewall) _firewall;
+
+	        Assert.Throws<FirewallLegacyNotSupportedException>(() =>
+		        {
+			        firewall.RuleExists("Anything");
+		        }
+	        );
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/WindowsFirewallHelper.Tests/FirewallLegacyTests.cs
+++ b/WindowsFirewallHelper.Tests/FirewallLegacyTests.cs
@@ -373,6 +373,18 @@ namespace WindowsFirewallHelper.Tests
 	        );
         }
 
+        [Test]
+        public void RemoveRuleByName()
+        {
+	        var firewall = (IFirewall) _firewall;
+
+	        Assert.Throws<FirewallLegacyNotSupportedException>(() =>
+		        {
+			        firewall.RemoveRuleByName("Anything");
+		        }
+	        );
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/WindowsFirewallHelper.Tests/FirewallWASTests.cs
+++ b/WindowsFirewallHelper.Tests/FirewallWASTests.cs
@@ -312,6 +312,33 @@ namespace WindowsFirewallHelper.Tests
             Assert.IsNull(checkRule);
         }
 
+        [Test]
+        public void RuleExists()
+        {
+	        var ruleName = RulesPrefix + Guid.NewGuid().ToString("N");
+	        var fileName = Path.GetTempFileName();
+	        var rule = _firewall.CreateApplicationRule(
+		        FirewallProfiles.Domain | FirewallProfiles.Private,
+		        ruleName,
+		        FirewallAction.Allow,
+		        FirewallDirection.Inbound,
+		        fileName,
+		        FirewallProtocol.Any
+	        );
+
+	        var firewall = (IFirewall) _firewall;
+			Assert.IsFalse(firewall.RuleExists(ruleName));
+			Assert.IsNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
+
+	        _firewall.Rules.Add(rule);
+			Assert.IsTrue(firewall.RuleExists(ruleName));
+			Assert.IsNotNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
+
+	        _firewall.Rules.Remove(rule);
+	        Assert.IsFalse(firewall.RuleExists(ruleName));
+	        Assert.IsNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/WindowsFirewallHelper.Tests/FirewallWASTests.cs
+++ b/WindowsFirewallHelper.Tests/FirewallWASTests.cs
@@ -339,6 +339,37 @@ namespace WindowsFirewallHelper.Tests
 	        Assert.IsNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
         }
 
+        [Test]
+        public void RemoveRuleByName()
+        {
+	        var ruleName = RulesPrefix + Guid.NewGuid().ToString("N");
+	        var fileName = Path.GetTempFileName();
+	        var rule = _firewall.CreateApplicationRule(
+		        FirewallProfiles.Domain | FirewallProfiles.Private,
+		        ruleName,
+		        FirewallAction.Allow,
+		        FirewallDirection.Inbound,
+		        fileName,
+		        FirewallProtocol.Any
+	        );
+
+	        var firewall = (IFirewall) _firewall;
+
+	        var initialRuleCount = _firewall.Rules.Count;
+	        
+	        firewall.RemoveRuleByName(ruleName);
+			Assert.AreEqual(initialRuleCount, _firewall.Rules.Count);
+			Assert.IsNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
+
+	        _firewall.Rules.Add(rule);
+	        Assert.AreEqual(initialRuleCount + 1, _firewall.Rules.Count);
+	        Assert.IsNotNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
+
+			firewall.RemoveRuleByName(ruleName);
+			Assert.AreEqual(initialRuleCount, _firewall.Rules.Count);
+			Assert.IsNull(firewall.Rules.FirstOrDefault(firewallRule => firewallRule.Name == ruleName));
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/WindowsFirewallHelper/FirewallLegacy.cs
+++ b/WindowsFirewallHelper/FirewallLegacy.cs
@@ -346,6 +346,12 @@ namespace WindowsFirewallHelper
 		        "Windows Firewall Legacy does not support accessing rules by name.");
         }
 
+        void IFirewall.RemoveRuleByName(string name)
+        {
+	        throw new FirewallLegacyNotSupportedException(
+		        "Windows Firewall Legacy does not support accessing rules by name.");
+        }
+
         /// <summary>
         ///     Returns the active firewall profile, if any
         /// </summary>

--- a/WindowsFirewallHelper/FirewallLegacy.cs
+++ b/WindowsFirewallHelper/FirewallLegacy.cs
@@ -339,6 +339,12 @@ namespace WindowsFirewallHelper
 
             return new FirewallLegacyPortRule(name, portNumber, activeProfile.Type) {Protocol = FirewallProtocol.TCP};
         }
+		
+        bool IFirewall.RuleExists(string name)
+        {
+	        throw new FirewallLegacyNotSupportedException(
+		        "Windows Firewall Legacy does not support accessing rules by name.");
+        }
 
         /// <summary>
         ///     Returns the active firewall profile, if any

--- a/WindowsFirewallHelper/FirewallWAS.cs
+++ b/WindowsFirewallHelper/FirewallWAS.cs
@@ -463,6 +463,11 @@ namespace WindowsFirewallHelper
 	        }
         }
 
+        void IFirewall.RemoveRuleByName(string name)
+        {
+			UnderlyingObject.Rules.Remove(name);
+        }
+
         /// <summary>
         ///     Returns the active firewall profile, if any
         /// </summary>

--- a/WindowsFirewallHelper/FirewallWAS.cs
+++ b/WindowsFirewallHelper/FirewallWAS.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using WindowsFirewallHelper.COMInterop;
 using WindowsFirewallHelper.Exceptions;
@@ -448,6 +449,18 @@ namespace WindowsFirewallHelper
             }
 
             return CreatePortRule(activeProfile.Type, name, action, direction, portNumber, protocol);
+        }
+		
+        bool IFirewall.RuleExists(string name)
+        {
+	        try
+	        {
+		        return UnderlyingObject.Rules.Item(name) != null;
+	        }
+	        catch (FileNotFoundException)
+	        {
+		        return false;
+	        }
         }
 
         /// <summary>

--- a/WindowsFirewallHelper/IFirewall.cs
+++ b/WindowsFirewallHelper/IFirewall.cs
@@ -195,6 +195,13 @@ namespace WindowsFirewallHelper
 		/// <returns>Flag whether rule with that name exists</returns>
         bool RuleExists(string name);
 
+		/// <summary>
+		///		Removes a rule with a given name.
+		///		Directly tries to remove the rule without enumerating <see cref="Rules"/> first.
+		/// </summary>
+		/// <param name="name">Name of the rule</param>
+		void RemoveRuleByName(string name);
+
         /// <summary>
         ///     Returns the active firewall profile, if any
         /// </summary>

--- a/WindowsFirewallHelper/IFirewall.cs
+++ b/WindowsFirewallHelper/IFirewall.cs
@@ -187,6 +187,14 @@ namespace WindowsFirewallHelper
         /// <returns>Returns the newly created rule object implementing <see cref="IFirewallRule" /> interface</returns>
         IFirewallRule CreatePortRule(string name, ushort portNumber);
 
+		/// <summary>
+		///		Checks whether a rule with a given name exists.
+		///		Directly tries to check existence without enumerating <see cref="Rules"/> first.
+		/// </summary>
+		/// <param name="name">Name of the rule</param>
+		/// <returns>Flag whether rule with that name exists</returns>
+        bool RuleExists(string name);
+
         /// <summary>
         ///     Returns the active firewall profile, if any
         /// </summary>


### PR DESCRIPTION
When accessing the _IFirewall.Rules_ collection all existing rules are enumerated for every access.
This means if I want e.g. delete a few rules by name or check whether a rule exists this becomes time consuming.

The interface _INetFwRules_ provides direct access to removal or existence check of rules.
I've forwarded that functionality to the _IFirewall_ interface.
