### PR TITLE
Add TryGetInstance and TryGetRegisteredProducts methods

### DIFF
--- a/WindowsFirewallHelper.Tests/FirewallManagerTests.cs
+++ b/WindowsFirewallHelper.Tests/FirewallManagerTests.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+
+namespace WindowsFirewallHelper.Tests
+{
+    public class FirewallManagerTests
+    {
+        [Test]
+        public void TryGetInstanceTest()
+        {
+            // NOTE: this may vary depending on the machine on which it is run.
+            var successful = FirewallManager.TryGetInstance(out var instance);
+
+            if (successful)
+            {
+                Assert.IsNotNull(instance);
+            }
+            else
+            {
+                Assert.IsNull(instance);
+            }
+        }
+
+        [Test]
+        public void TryGetRegisteredProductsTest()
+        {
+            // NOTE: this may vary depending on the machine on which it is run.
+            var successful = FirewallManager.TryGetRegisteredProducts(out var collection);
+
+            if (successful)
+            {
+                Assert.IsNotNull(collection);
+            }
+            else
+            {
+                Assert.IsNull(collection);
+            }
+        }
+    }
+}

--- a/WindowsFirewallHelper.Tests/WindowsFirewallHelper.Tests.csproj
+++ b/WindowsFirewallHelper.Tests/WindowsFirewallHelper.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WindowsFirewallHelper/FirewallManager.cs
+++ b/WindowsFirewallHelper/FirewallManager.cs
@@ -16,6 +16,7 @@ namespace WindowsFirewallHelper
         /// <summary>
         ///     Returns a instance of the active firewall
         /// </summary>
+        /// <exception cref="NotSupportedException">Thrown if firewall API version is not supported.</exception>
         public static IFirewall Instance
         {
             get
@@ -33,6 +34,25 @@ namespace WindowsFirewallHelper
                 }
 
                 throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        ///     Attempts to get an instance of the active firewall.
+        /// </summary>
+        /// <param name="instance">Outputs the active firewall instance, if successful.</param>
+        /// <returns>Returns true if successful, otherwise false.</returns>
+        public static bool TryGetInstance(out IFirewall instance)
+        {
+            try
+            {
+                instance = Instance;
+                return true;
+            }
+            catch
+            {
+                instance = null;
+                return false;
             }
         }
 
@@ -62,9 +82,26 @@ namespace WindowsFirewallHelper
         /// <summary>
         ///     Returns the list of all registered third party firewalls
         /// </summary>
-        public static IFirewallProductsCollection RegisteredProducts
+        /// <exception cref="NotSupportedException">Thrown if third party firewalls are not supported.</exception>
+        public static IFirewallProductsCollection RegisteredProducts => new FirewallProductsCollection(GetProducts());
+
+        /// <summary>
+        ///     Attempts to get the list of all registered third party firewalls.
+        /// </summary>
+        /// <param name="collection">Outputs the collection of third party firewalls, if successful.</param>
+        /// <returns>Returns true if successful, otherwise false.</returns>
+        public static bool TryGetRegisteredProducts(out IFirewallProductsCollection collection)
         {
-            get => new FirewallProductsCollection(GetProducts());
+            try
+            {
+                collection = RegisteredProducts;
+                return true;
+            }
+            catch
+            {
+                collection = null;
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The static Instance and RegisteredProducts properties can throw in some cases. This adds safer `Try` versions that prevent having to add try/catch in the calling code. Added unit tests for these methods, although given the current implementation, these do not represent 100% coverage since the branch may vary depending on the machine on which it is run. 

Updated test app to .NET Core 3.1 (previously was 2.2, which is no longer supported) and updated the NuGet dependencies for the test project so that it can be run on the latest VS2019.